### PR TITLE
CV2 Rando Tracker Logic Fix

### DIFF
--- a/CV2 Rando Tracker/locations/rooms.json
+++ b/CV2 Rando Tracker/locations/rooms.json
@@ -273,6 +273,7 @@
             "sections": [
               {
                 "name": "Vendor",
+                "access_rules": [ "white", "{}" ],
                 "item_count": 1
               }
             ]
@@ -289,7 +290,7 @@
             "sections": [
               {
                 "name": "Pedestool",
-                "access_rules": [ "stake", "{}" ],
+                "access_rules": [ "white,stake", "{}" ],
                 "item_count": 1
               }
             ]
@@ -330,7 +331,7 @@
             "sections": [
               {
                 "name": "Pedestool",
-                "access_rules": [ "stake", "blue", "red", "{}" ],
+                "access_rules": [ "blue,stake", "red,stake", "{}" ],
                 "item_count": 1
               }
             ]
@@ -371,7 +372,7 @@
             "sections": [
               {
                 "name": "Pedestool",
-                "access_rules": [ "stake", "heart", "{}" ],
+                "access_rules": [ "stake,heart", "{}" ],
                 "item_count": 1
               }
             ]
@@ -412,7 +413,7 @@
             "sections": [
               {
                 "name": "Vendor",
-                "access_rules": [ "red", "{}" ],
+                "access_rules": [ "red,hwater,laurels", "red,nail,laurels", "{}" ],
                 "item_count": 1
               }
             ]
@@ -429,7 +430,7 @@
             "sections": [
               {
                 "name": "Vendor",
-                "access_rules": [ "red", "{}" ],
+                "access_rules": [ "red,hwater,laurels", "red,nail,laurels", "{}" ],
                 "item_count": 1
               }
             ]
@@ -446,7 +447,7 @@
             "sections": [
               {
                 "name": "Pedestool",
-                "access_rules": [ "stake", "red", "{}" ],
+                "access_rules": [ "red,hwater,laurels,stake", "red,nail,laurels,stake", "{}" ],
                 "item_count": 1
               }
             ]
@@ -463,7 +464,7 @@
             "sections": [
               {
                 "name": "Boss item",
-                "access_rules": [ "red", "{}" ],
+                "access_rules": [ "red,hwater,laurels", "red,nail,laurels", "{}" ],
                 "item_count": 1
               }
             ]
@@ -487,7 +488,7 @@
             "sections": [
               {
                 "name": "Vendor",
-                "access_rules": [ "red", "hwater", "nail", "{}" ],
+                "access_rules": [ "red,nail", "red,hwater", "{}" ],
                 "item_count": 1
               }
             ]
@@ -504,7 +505,7 @@
             "sections": [
               {
                 "name": "Pedestool",
-                "access_rules": [ "red", "stake", "nail", "{}" ],
+                "access_rules": [ "red,hwater,stake", "red,nail,stake", "{}" ],
                 "item_count": 1
               }
             ]


### PR DESCRIPTION
Fixed issues with the tracker improperly displaying certain checks as green despite not having all the items. Added White Crystal logic to Berkeley Mansion, added laurels and nail or holy water as a requirement for Laruba Mansion, and fixed the Oak Stake checks to require an oak stake in addition to the requirements to enter the mansion. I tested the changes on my own folder and they work.